### PR TITLE
Feaure/add shipping countries fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,46 @@ For Preview to work , you also need the [wp-graphql-jwt-authentication](https://
 
 * Registers custom end points
 
-4. Custom Header and Footer GraphQL fields when using [wp-graphql](https://github.com/wp-graphql/wp-graphql) plugin.
+4. Following fields when using [wp-graphql](https://github.com/wp-graphql/wp-graphql) plugin.
+
+* Custom Header and Footer GraphQL
 ![](assets/images/screenshot-2.png)
+
+* WooCommerce Countries and States
+
+```javascript
+{
+  wooCountries {
+    countries
+  }
+  wooStates(countryCode: "in") {
+    states
+  }
+}
+```
+
+* WooCommerce Shipping Zones.
+
+```javascript
+{
+  shippingInfo {
+    shippingZones
+    storePostCode
+  }
+}
+```
+
+* Schema Details
+
+```javascript
+  posts {
+    nodes {
+      seo {
+        schemaDetails
+      }
+    }
+  }
+```
 
 ## Available Endpoints:
 

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -14,6 +14,9 @@ use Headless_CMS\Features\Inc\Api\Home_Page;
 use Headless_CMS\Features\Inc\Api\Post_By_Tax;
 use Headless_CMS\Features\Inc\Schema\Header_Footer_Schema;
 use Headless_CMS\Features\Inc\Schema\Post_Schema;
+use Headless_CMS\Features\Inc\Schema\Register_Countries;
+use Headless_CMS\Features\Inc\Schema\Register_Shipping;
+use Headless_CMS\Features\Inc\Schema\Register_States;
 use Headless_CMS\Features\Inc\Schema\Seo;
 use Headless_CMS\Features\Inc\Schema\Sticky_Post;
 use \Headless_CMS\Features\Inc\Traits\Singleton;
@@ -48,7 +51,10 @@ class Plugin {
 		Sticky_Post::get_instance();
 		Post_Schema::get_instance();
 		Seo::get_instance();
-		
+		Register_Countries::get_instance();
+		Register_States::get_instance();
+		Register_Shipping::get_instance();
+
 		// Preview.
 		Preview::get_instance();
 

--- a/inc/classes/schema/class-header-footer-schema.php
+++ b/inc/classes/schema/class-header-footer-schema.php
@@ -91,7 +91,7 @@ class Header_Footer_Schema {
 				'resolve'     => function () {
 
 					/**
-					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * Here you need to return data that matches the shape of the "HCMSHeader" type. You could get
 					 * the data from the WP Database, an external API, or static values.
 					 * For example in this case we are getting it from WordPress database.
 					 */
@@ -152,7 +152,7 @@ class Header_Footer_Schema {
 				'resolve'     => function () {
 
 					/**
-					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * Here you need to return data that matches the shape of the "HCMSFooter" type. You could get
 					 * the data from the WP Database, an external API, or static values.
 					 * For example in this case we are getting it from WordPress database.
 					 */

--- a/inc/classes/schema/class-post-schema.php
+++ b/inc/classes/schema/class-post-schema.php
@@ -50,7 +50,7 @@ class Post_Schema {
 			'coAuthors',
 			[
 				'type'        => 'String',
-				'description' => __( 'Co Authors', 'wp-graphql' ),
+				'description' => __( 'Co Authors', 'headless-cms' ),
 				'resolve'     => function ($post) {
 					return function_exists( 'get_coauthors' ) ? wp_json_encode( get_coauthors( $post->ID ) ) : '';
 				},

--- a/inc/classes/schema/class-register-countries.php
+++ b/inc/classes/schema/class-register-countries.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Register_Countries class.
+ *
+ * @package headless-cms
+ */
+
+namespace Headless_CMS\Features\Inc\Schema;
+
+use Headless_CMS\Features\Inc\Traits\Singleton;
+
+/**
+ * Class Register_Countries
+ */
+class Register_Countries {
+
+	use Singleton;
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * To setup action/filter.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+
+		/**
+		 * Action
+		 */
+
+		// Register Header Type and Field.
+		add_action( 'graphql_register_types', [ $this, 'register_countries_fields' ] );
+
+	}
+
+	/**
+	 * Register field.
+	 */
+	function register_countries_fields() {
+
+		register_graphql_object_type( 'WooCountries', [
+			'description' => __( 'Shipping Zones Type', 'headless-cms' ),
+			'fields' => [
+				'countries'  => [ 'type' => 'String' ],
+			]
+		] );
+
+		register_graphql_field(
+			'RootQuery',
+			'wooCountries',
+			[
+				'description' => __( 'Countries', 'headless-cms' ),
+				'type'        => 'WooCountries',
+				'resolve'     => function () {
+
+					$countries = class_exists('WooCommerce') ? WC()->countries : [];
+
+					/**
+					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * the data from the WP Database, an external API, or static values.
+					 * For example in this case we are getting it from WordPress database.
+					 */
+					return [
+						'countries' => wp_json_encode($countries),
+					];
+
+				},
+			]
+		);
+	}
+
+}

--- a/inc/classes/schema/class-register-countries.php
+++ b/inc/classes/schema/class-register-countries.php
@@ -34,7 +34,7 @@ class Register_Countries {
 		 * Action
 		 */
 
-		// Register Header Type and Field.
+		// Register Countries Field.
 		add_action( 'graphql_register_types', [ $this, 'register_countries_fields' ] );
 
 	}
@@ -45,7 +45,7 @@ class Register_Countries {
 	function register_countries_fields() {
 
 		register_graphql_object_type( 'WooCountries', [
-			'description' => __( 'Shipping Zones Type', 'headless-cms' ),
+			'description' => __( 'Countries Type', 'headless-cms' ),
 			'fields' => [
 				'countries'  => [ 'type' => 'String' ],
 			]
@@ -62,7 +62,7 @@ class Register_Countries {
 					$countries = class_exists('WooCommerce') ? WC()->countries : [];
 
 					/**
-					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * Here you need to return data that matches the shape of the "WooCountries" type. You could get
 					 * the data from the WP Database, an external API, or static values.
 					 * For example in this case we are getting it from WordPress database.
 					 */

--- a/inc/classes/schema/class-register-shipping.php
+++ b/inc/classes/schema/class-register-shipping.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Register_Shipping class.
+ *
+ * @package headless-cms
+ */
+
+namespace Headless_CMS\Features\Inc\Schema;
+
+use Headless_CMS\Features\Inc\Traits\Singleton;
+
+/**
+ * Class Register_Shipping
+ */
+class Register_Shipping {
+
+	use Singleton;
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * To setup action/filter.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+
+		/**
+		 * Action
+		 */
+
+		// Register Shipping Zones fields.
+		add_action( 'graphql_register_types', [ $this, 'register_shipping_zones_fields' ] );
+
+	}
+
+	/**
+	 * Register field.
+	 */
+	function register_shipping_zones_fields() {
+
+		register_graphql_object_type( 'ShippingInfo', [
+			'description' => __( 'Shipping Zones Type', 'headless-cms' ),
+			'fields' => [
+				'shippingZones'  => [ 'type' => 'String' ],
+				'storePostCode' => [ 'type' => 'Integer' ],
+			]
+		] );
+
+		register_graphql_field(
+			'RootQuery',
+			'shippingInfo',
+			[
+				'description' => __( 'Shipping Zones', 'headless-cms' ),
+				'type'        => 'ShippingInfo',
+				'resolve'     => function () {
+
+					$zone_locations = $this->get_zone_locations();
+					$store_post_code = class_exists('WooCommerce') ? WC()->countries->get_base_postcode() : 0;
+
+					/**
+					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * the data from the WP Database, an external API, or static values.
+					 * For example in this case we are getting it from WordPress database.
+					 */
+					return [
+						'shippingZones' => wp_json_encode($zone_locations),
+						'storePostCode' => intval( $store_post_code ),
+					];
+
+				},
+			]
+		);
+	}
+
+	public function get_store_address() {
+		$store_address = '';
+		if( class_exists( 'WC_Countries' ) ) {
+			$store_address = get_option( 'woocommerce_store_address' );
+		}
+
+		return $store_address;
+	}
+
+	/**
+	 * Get Zone locations
+	 *
+	 * @return array $zone_locations Zone locations.
+	 */
+	public function get_zone_locations() {
+		$zone_locations = [];
+
+		if( class_exists( 'WC_Shipping_Zones' ) ) {
+			$all_zones = \WC_Shipping_Zones::get_zones();
+			if ( ! empty( $all_zones ) && is_array( $all_zones ) ) {
+				foreach ((array) $all_zones as $key => $the_zone ) {
+
+					$zone_info = [
+						'zone_name'           => $the_zone['zone_name'],
+						'country_names'       => $the_zone['formatted_zone_location'],
+						'zone_location_codes' => $the_zone['zone_locations'],
+						'shipping_methods'    => $this->get_shipping_methods( $the_zone['shipping_methods'] ),
+					];
+					array_push($zone_locations, $zone_info);
+
+				}
+			}
+		}
+
+		return $zone_locations;
+	}
+
+	/**
+	 * Get Shipping methods.
+	 *
+	 * @param array $shipping_methods_data Shipping method data.
+	 *
+	 * @return array Shipping methods.
+	 */
+	public function get_shipping_methods($shipping_methods_data) {
+
+		$shipping_methods = [];
+
+		if ( empty( $shipping_methods_data ) || !is_array( $shipping_methods_data ) ) {
+			return $shipping_methods;
+		}
+
+		foreach ((array) $shipping_methods_data as $key => $shipping_method ) {
+			array_push($shipping_methods, [
+				'method_title' => ! empty($shipping_method->instance_settings['title']) ? $shipping_method->instance_settings['title'] : '',
+			]);
+		}
+
+		return $shipping_methods;
+	}
+
+}

--- a/inc/classes/schema/class-register-shipping.php
+++ b/inc/classes/schema/class-register-shipping.php
@@ -64,7 +64,7 @@ class Register_Shipping {
 					$store_post_code = class_exists('WooCommerce') ? WC()->countries->get_base_postcode() : 0;
 
 					/**
-					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * Here you need to return data that matches the shape of the "ShippingInfo" type. You could get
 					 * the data from the WP Database, an external API, or static values.
 					 * For example in this case we are getting it from WordPress database.
 					 */

--- a/inc/classes/schema/class-register-states.php
+++ b/inc/classes/schema/class-register-states.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Register_States class.
+ *
+ * @package headless-cms
+ */
+
+namespace Headless_CMS\Features\Inc\Schema;
+
+use Headless_CMS\Features\Inc\Traits\Singleton;
+
+/**
+ * Class Register_States
+ */
+class Register_States {
+
+	use Singleton;
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * To setup action/filter.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+
+		/**
+		 * Action
+		 */
+
+		// Register States Field.
+		add_action( 'graphql_register_types', [ $this, 'register_states_fields' ] );
+
+	}
+
+	/**
+	 * Register field.
+	 */
+	function register_states_fields() {
+
+		register_graphql_object_type( 'WooStates', [
+			'description' => __( 'States Type', 'headless-cms' ),
+			'fields' => [
+				'states'  => [ 'type' => 'String' ],
+			]
+		] );
+
+		register_graphql_field(
+			'RootQuery',
+			'wooStates',
+			[
+				'description' => __( 'States', 'headless-cms' ),
+				'type'        => 'WooStates',
+				'args'        => [
+					'countryCode' => [
+						'type' => 'String',
+					],
+				],
+				'resolve'     => function ( $source, $args, $context, $info ) {
+					$states = [];
+
+					if ( isset( $args['countryCode'] ) && ! empty( $args['countryCode'] ) ) {
+						$states = class_exists( 'WooCommerce' ) ? WC()->countries->get_states( strtoupper($args['countryCode']) ) : [];
+					}
+
+					/**
+					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * the data from the WP Database, an external API, or static values.
+					 * For example in this case we are getting it from WordPress database.
+					 */
+					return [
+						'states' => wp_json_encode($states),
+					];
+
+				},
+			]
+		);
+	}
+
+}

--- a/inc/classes/schema/class-register-states.php
+++ b/inc/classes/schema/class-register-states.php
@@ -70,7 +70,7 @@ class Register_States {
 					}
 
 					/**
-					 * Here you need to return data that matches the shape of the "Dog" type. You could get
+					 * Here you need to return data that matches the shape of the "WooStates" type. You could get
 					 * the data from the WP Database, an external API, or static values.
 					 * For example in this case we are getting it from WordPress database.
 					 */


### PR DESCRIPTION
- Adds Shipping Zones in GraphQL 
- Adds field to fetch all countries and states by country code for checkout form.

* WooCommerce Countries and States

```javascript
{
  wooCountries {
    countries
  }
  wooStates(countryCode: "in") {
    states
  }
}
```

* WooCommerce Shipping Zones.

```javascript
{
  shippingInfo {
    shippingZones
    storePostCode
  }
}
```