### PR TITLE
Add WooCommerce Countries and States REST API Endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A WordPress plugin that adds features to use WordPress as a headless CMS with any front-end environment using REST API",
   "type": "wordpress-plugin",
   "license": "GPL-3.0+",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
 	"wordpress",
 	"plugin"

--- a/headless-cms.php
+++ b/headless-cms.php
@@ -7,7 +7,7 @@
  * Author URI:  https://codeytek.com
  * License:     GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.0.1
+ * Version:     2.0.2
  * Text Domain: headless-cms
  *
  * @package headless-cms

--- a/inc/classes/api/class-wc-countries.php
+++ b/inc/classes/api/class-wc-countries.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Wc_Countries class.
+ *
+ * @package headless-cms
+ */
+
+namespace Headless_CMS\Features\Inc\Api;
+
+
+use Headless_CMS\Features\Inc\Traits\Singleton;
+use \WP_REST_Server;
+
+/**
+ * Class Header_Footer_Api
+ */
+class Wc_Countries {
+
+	use Singleton;
+
+	/**
+	 * Endpoint namespace
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'rae/v1';
+
+	/**
+	 * Route name
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc/countries';
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+
+		$this->setup_hooks();
+	}
+
+	/**
+	 * To setup action/filter.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+
+		/**
+		 * Action
+		 */
+		add_action( 'rest_api_init', [ $this, 'register_rest_api_endpoints' ] );
+
+	}
+
+	/**
+	 * Register endpoints.
+	 */
+	public function register_rest_api_endpoints() {
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_countries' ],
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get countries
+	 *
+	 * @param \WP_REST_Request $request
+	 *
+	 * @return \WP_REST_Response
+	 *
+	 * @since 1.0.0
+	 *
+	 */
+	public function get_countries( \WP_REST_Request $request ): \WP_REST_Response {
+
+		// All countries for billing.
+		$all_countries     = class_exists( 'WooCommerce' ) ? WC()->countries : [];
+		$billing_countries = ! empty( $all_countries->countries ) ? $all_countries->countries : [];
+		$billing_countries = $this->get_formatted_countries( $billing_countries );
+
+		// All countries with states for shipping.
+		$shipping_countries = class_exists( 'WooCommerce' ) ? WC()->countries->get_shipping_countries() : [];;
+		$shipping_countries = ! empty( $shipping_countries ) ? $shipping_countries : [];
+		$shipping_countries = $this->get_formatted_countries( $shipping_countries );
+
+		/**
+		 * Here you need to return data that matches the shape of the "WooCountries" type. You could get
+		 * the data from the WP Database, an external API, or static values.
+		 * For example in this case we are getting it from WordPress database.
+		 */
+		$data = [
+			'billingCountries'  => $billing_countries,
+			'shippingCountries' => $shipping_countries,
+		];
+
+		return rest_ensure_response( $data );
+	}
+
+	public function get_formatted_countries( $countries ) {
+
+		$formatted_countries = [];
+
+		if ( empty( $countries ) && ! is_array( $countries ) ) {
+			return $formatted_countries;
+		}
+
+		foreach ( $countries as $countryCode => $countryName ) {
+			array_push( $formatted_countries, [
+				'countryCode' => $countryCode,
+				'countryName' => $countryName,
+			] );
+		}
+
+		return $formatted_countries;
+	}
+}

--- a/inc/classes/api/class-wc-countries.php
+++ b/inc/classes/api/class-wc-countries.php
@@ -12,7 +12,7 @@ use Headless_CMS\Features\Inc\Traits\Singleton;
 use \WP_REST_Server;
 
 /**
- * Class Header_Footer_Api
+ * Class Wc_Countries
  */
 class Wc_Countries {
 
@@ -59,6 +59,7 @@ class Wc_Countries {
 	 */
 	public function register_rest_api_endpoints() {
 
+		// e.g. http://example.com/wp-json/rae/v1/wc/countries
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
@@ -107,6 +108,13 @@ class Wc_Countries {
 		return rest_ensure_response( $data );
 	}
 
+	/**
+	 * Get Formatted Countries.
+	 *
+	 * @param $countries
+	 *
+	 * @return array
+	 */
 	public function get_formatted_countries( $countries ) {
 
 		$formatted_countries = [];

--- a/inc/classes/api/class-wc-states.php
+++ b/inc/classes/api/class-wc-states.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Wc_States class.
+ *
+ * @package headless-cms
+ */
+
+namespace Headless_CMS\Features\Inc\Api;
+
+
+use Headless_CMS\Features\Inc\Traits\Singleton;
+use \WP_REST_Server;
+
+/**
+ * Class Wc_States
+ */
+class Wc_States {
+
+	use Singleton;
+
+	/**
+	 * Endpoint namespace
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'rae/v1';
+
+	/**
+	 * Route name
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc/states';
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+
+		$this->setup_hooks();
+	}
+
+	/**
+	 * To setup action/filter.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+
+		/**
+		 * Action
+		 */
+		add_action( 'rest_api_init', [ $this, 'register_rest_api_endpoints' ] );
+
+	}
+
+	/**
+	 * Register endpoints.
+	 */
+	public function register_rest_api_endpoints() {
+
+		// e.g. http://example.com/wp-json/rae/v1/wc/states?countryCode=IN
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_states' ],
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get States by
+	 *
+	 * @param \WP_REST_Request $request
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function get_states( \WP_REST_Request $request ): \WP_REST_Response {
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return rest_ensure_response( [] );
+		}
+
+		$parameters  = $request->get_params();
+		$countryCode = ! empty( $parameters['countryCode'] ) ? sanitize_text_field( $parameters['countryCode'] ) : '';
+
+		$states = ! empty( $countryCode ) ? WC()->countries->get_states( strtoupper( $countryCode ) ) : [];
+		$states = $this->get_formatted_states( $states );
+
+		/**
+		 * Here you need to return data that matches the shape of the "WooStates" type. You could get
+		 * the data from the WP Database, an external API, or static values.
+		 * For example in this case we are getting it from WordPress database.
+		 */
+		$data = [
+			'states' => $states,
+		];
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Get Formatted States.
+	 *
+	 * @param array $states
+	 *
+	 * @return array
+	 */
+	public function get_formatted_states( array $states = [] ): array {
+
+		$formatted_states = [];
+
+		if ( empty( $states ) && ! is_array( $states ) ) {
+			return $formatted_states;
+		}
+
+		foreach ( $states as $stateCode => $stateName ) {
+			array_push( $formatted_states, [
+				'stateCode' => $stateCode,
+				'stateName' => $stateName,
+			] );
+		}
+
+		return $formatted_states;
+	}
+}

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -14,6 +14,7 @@ use Headless_CMS\Features\Inc\Api\Header_Footer_Api;
 use Headless_CMS\Features\Inc\Api\Home_Page;
 use Headless_CMS\Features\Inc\Api\Wc_Cart;
 use Headless_CMS\Features\Inc\Api\Post_By_Tax;
+use Headless_CMS\Features\Inc\Api\Wc_Countries;
 use Headless_CMS\Features\Inc\Mutations\Add_Wishlist;
 use Headless_CMS\Features\Inc\Mutations\Delete_Wishlist;
 use Headless_CMS\Features\Inc\Queries\Get_Wishlist;
@@ -53,6 +54,7 @@ class Plugin {
 		Home_Page::get_instance();
 		Post_By_Tax::get_instance();
 		Wc_Cart::get_instance();
+		Wc_Countries::get_instance();
 
 		// Queries.
 		Header_Footer_Schema::get_instance();

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -15,6 +15,7 @@ use Headless_CMS\Features\Inc\Api\Home_Page;
 use Headless_CMS\Features\Inc\Api\Wc_Cart;
 use Headless_CMS\Features\Inc\Api\Post_By_Tax;
 use Headless_CMS\Features\Inc\Api\Wc_Countries;
+use Headless_CMS\Features\Inc\Api\Wc_States;
 use Headless_CMS\Features\Inc\Mutations\Add_Wishlist;
 use Headless_CMS\Features\Inc\Mutations\Delete_Wishlist;
 use Headless_CMS\Features\Inc\Queries\Get_Wishlist;
@@ -55,6 +56,7 @@ class Plugin {
 		Post_By_Tax::get_instance();
 		Wc_Cart::get_instance();
 		Wc_Countries::get_instance();
+		Wc_States::get_instance();
 
 		// Queries.
 		Header_Footer_Schema::get_instance();


### PR DESCRIPTION
-Adds WooCommerce Countries and States REST API Endpoints
- `/wp-json/rae/v1/wc/countries/`
- `/wp-json/rae/v1/wc/states?countryCode=IN`