### PR TITLE
Fix issue with accessing array offset on boolean value in get_custom_logo_url function

### DIFF
--- a/inc/classes/api/class-header-footer-api.php
+++ b/inc/classes/api/class-header-footer-api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Header_Footer_Api class.
  *
@@ -15,14 +16,16 @@ use WP_REST_Response;
 /**
  * Class Header_Footer_Api
  */
-class Header_Footer_Api {
+class Header_Footer_Api
+{
 
 	use Singleton;
 
 	/**
 	 * Construct method.
 	 */
-	protected function __construct() {
+	protected function __construct()
+	{
 		$this->setup_hooks();
 	}
 
@@ -31,21 +34,22 @@ class Header_Footer_Api {
 	 *
 	 * @return void
 	 */
-	protected function setup_hooks() {
+	protected function setup_hooks()
+	{
 
 		$this->route = '/header-footer';
 
 		/**
 		 * Action
 		 */
-		add_action( 'rest_api_init', [ $this, 'rest_posts_endpoints' ] );
-
+		add_action('rest_api_init', [$this, 'rest_posts_endpoints']);
 	}
 
 	/**
 	 * Register posts endpoints.
 	 */
-	public function rest_posts_endpoints() {
+	public function rest_posts_endpoints()
+	{
 
 		/**
 		 * Handle Posts Request: GET Request
@@ -64,7 +68,7 @@ class Header_Footer_Api {
 			$this->route,
 			[
 				'method'   => 'GET',
-				'callback' => [ $this, 'rest_endpoint_handler' ],
+				'callback' => [$this, 'rest_endpoint_handler'],
 				'permission_callback' => '__return_true',
 			]
 		);
@@ -79,27 +83,28 @@ class Header_Footer_Api {
 	 *
 	 * @return WP_Error|WP_REST_Response response object.
 	 */
-	public function rest_endpoint_handler( WP_REST_Request $request ) {
+	public function rest_endpoint_handler(WP_REST_Request $request)
+	{
 		$response                = [];
 		$parameters              = $request->get_params();
-		$header_menu_location_id = ! empty( $parameters['header_location_id'] ) ? sanitize_text_field( $parameters['header_location_id'] ) : '';
-		$footer_menu_location_id = ! empty( $parameters['footer_location_id'] ) ? sanitize_text_field( $parameters['footer_location_id'] ) : '';
+		$header_menu_location_id = !empty($parameters['header_location_id']) ? sanitize_text_field($parameters['header_location_id']) : '';
+		$footer_menu_location_id = !empty($parameters['footer_location_id']) ? sanitize_text_field($parameters['footer_location_id']) : '';
 
 		// Error Handling.
 		$error = new WP_Error();
 
-		$header_menu_items = $this->get_nav_menu_items( $header_menu_location_id );
-		$footer_menu_items = $this->get_nav_menu_items( $footer_menu_location_id );
+		$header_menu_items = $this->get_nav_menu_items($header_menu_location_id);
+		$footer_menu_items = $this->get_nav_menu_items($footer_menu_location_id);
 
 		// If any menus found.
-		if ( ! empty( $header_menu_items ) || ! empty( $footer_menu_items ) ) {
+		if (!empty($header_menu_items) || !empty($footer_menu_items)) {
 
 			$response['status'] = 200;
 			$response['data']   = [
 				'header' => [
-					'siteLogoUrl'     => $this->get_custom_logo_url( 'custom_logo' ),
-					'siteTitle'       => get_bloginfo( 'title' ),
-					'siteDescription' => get_bloginfo( 'description' ),
+					'siteLogoUrl'     => $this->get_custom_logo_url('custom_logo'),
+					'siteTitle'       => get_bloginfo('title'),
+					'siteDescription' => get_bloginfo('description'),
 					'favicon'         => get_site_icon_url(),
 					'headerMenuItems' => $header_menu_items,
 				],
@@ -107,22 +112,19 @@ class Header_Footer_Api {
 					'footerMenuItems' => $footer_menu_items,
 					'socialLinks'     => $this->get_social_icons(),
 					'copyrightText'   => $this->get_copyright_text(),
-					'sidebarOne'      => $this->get_sidebar( 'hcms-footer-sidebar-1' ),
-					'sidebarTwo'      => $this->get_sidebar( 'hcms-footer-sidebar-2' ),
+					'sidebarOne'      => $this->get_sidebar('hcms-footer-sidebar-1'),
+					'sidebarTwo'      => $this->get_sidebar('hcms-footer-sidebar-2'),
 				],
 			];
-
 		} else {
 
 			// If the posts not found.
-			$error->add( 406, __( 'Data not found', 'rest-api-endpoints' ) );
+			$error->add(406, __('Data not found', 'rest-api-endpoints'));
 
 			return $error;
-
 		}
 
-		return new WP_REST_Response( $response );
-
+		return new WP_REST_Response($response);
 	}
 
 	/**
@@ -132,11 +134,26 @@ class Header_Footer_Api {
 	 *
 	 * @return string Image.
 	 */
-	public function get_custom_logo_url( $key ) {
+	public function get_custom_logo_url($key)
+	{
+		if (function_exists('has_custom_logo') && has_custom_logo()) {
+			$custom_logo_id = get_theme_mod($key);
+			$image = wp_get_attachment_image_src($custom_logo_id, 'full');
 
-		$custom_logo_id = get_theme_mod( $key );
-		$image          = wp_get_attachment_image_src( $custom_logo_id, 'full' );
-		return $image[0];
+			// Check if $image is an array and not empty before accessing its elements.
+			if (is_array($image) && !empty($image)) {
+				// Access the array element.
+				$image_url = $image[0];
+			} else {
+				// Handle the case where $image is not an array or empty.
+				$image_url = ''; // Or any default value you want to assign.
+			}
+		} else {
+			// If the theme doesn't support custom logo or no logo is set, provide a fallback URL or value.
+			$image_url = ''; // Or any default URL or value you want to assign.
+		}
+
+		return $image_url;
 	}
 
 	/**
@@ -144,28 +161,28 @@ class Header_Footer_Api {
 	 *
 	 * @return array $social_icons
 	 */
-	public function get_social_icons() {
+	public function get_social_icons()
+	{
 
 		$social_icons      = [];
-		$social_icons_name = [ 'facebook', 'twitter', 'instagram', 'youtube' ];
+		$social_icons_name = ['facebook', 'twitter', 'instagram', 'youtube'];
 
-		foreach ( $social_icons_name as $social_icon_name ) {
+		foreach ($social_icons_name as $social_icon_name) {
 
-			$social_link = get_theme_mod( sprintf( 'rae_%s_link', $social_icon_name ) );
+			$social_link = get_theme_mod(sprintf('rae_%s_link', $social_icon_name));
 
-			if ( $social_link ) {
+			if ($social_link) {
 				array_push(
 					$social_icons,
 					[
-						'iconName' => esc_attr( $social_icon_name ),
-						'iconUrl'  => esc_url( $social_link ),
+						'iconName' => esc_attr($social_icon_name),
+						'iconUrl'  => esc_url($social_link),
 					]
 				);
 			}
 		}
 
 		return $social_icons;
-
 	}
 
 	/**
@@ -173,8 +190,9 @@ class Header_Footer_Api {
 	 *
 	 * @return mixed
 	 */
-	public function get_copyright_text() {
-		return get_theme_mod( 'rae_footer_text' );
+	public function get_copyright_text()
+	{
+		return get_theme_mod('rae_footer_text');
 	}
 
 	/**
@@ -185,9 +203,10 @@ class Header_Footer_Api {
 	 *
 	 * @return array $menu_data Menu items array of Objects.
 	 */
-	public function get_nav_menu_items( $location, $args = [] ) {
+	public function get_nav_menu_items($location, $args = [])
+	{
 
-		if ( empty( $location ) ) {
+		if (empty($location)) {
 			return '';
 		}
 
@@ -195,17 +214,17 @@ class Header_Footer_Api {
 		$locations = get_nav_menu_locations();
 
 		// Get object id by location.
-		$object = wp_get_nav_menu_object( $locations[ $location ] );
+		$object = wp_get_nav_menu_object($locations[$location]);
 
 		// Get menu items by menu name.
-		$menu_data  = wp_get_nav_menu_items( $object->name, $args );
+		$menu_data  = wp_get_nav_menu_items($object->name, $args);
 		$menu_items = [];
 
-		if ( ! empty( $menu_data ) ) {
+		if (!empty($menu_data)) {
 
 			// Menus ( Loop through the menu, and push all the parent menu items first ).
-			foreach ( $menu_data as $item ) {
-				if ( empty( $item->menu_item_parent ) ) {
+			foreach ($menu_data as $item) {
+				if (empty($item->menu_item_parent)) {
 					$menu_item             = [];
 					$menu_item['ID']       = $item->ID;
 					$menu_item['title']    = $item->title;
@@ -213,18 +232,18 @@ class Header_Footer_Api {
 					$menu_item['children'] = [];
 
 					// We are also getting the page slug and the page id that this menu is linked to.
-					$menu_item['pageSlug'] = get_post_field( 'post_name', $item->object_id );
-					$menu_item['pageID']   = intval( $item->object_id );
+					$menu_item['pageSlug'] = get_post_field('post_name', $item->object_id);
+					$menu_item['pageID']   = intval($item->object_id);
 
-					array_push( $menu_items, $menu_item );
+					array_push($menu_items, $menu_item);
 				}
 			}
 
 			// Submenus: ( Loop through the menu again, and push all the child menu items ).
-			foreach ( $menu_data as $item ) {
+			foreach ($menu_data as $item) {
 
 				// If the menu has a parent, it means its a child menu.
-				if ( $item->menu_item_parent ) {
+				if ($item->menu_item_parent) {
 
 					// Create a child menu array.
 					$submenu_item          = [];
@@ -233,29 +252,27 @@ class Header_Footer_Api {
 					$submenu_item['url']   = $item->url;
 
 					// We are also getting the page slug and the page id that this menu is linked to.
-					$submenu_item['pageSlug'] = get_post_field( 'post_name', $item->object_id );
-					$submenu_item['pageID']   = intval( $item->object_id );
+					$submenu_item['pageSlug'] = get_post_field('post_name', $item->object_id);
+					$submenu_item['pageID']   = intval($item->object_id);
 
 					// Loop through the menu items and find the parent whose child this is.
-					foreach ( $menu_items as $key => $parent_item ) {
+					foreach ($menu_items as $key => $parent_item) {
 
 						// if the parent id of this child menu, is same as the parent menu id.
-						if ( intval( $item->menu_item_parent ) === $parent_item['ID'] ) {
+						if (intval($item->menu_item_parent) === $parent_item['ID']) {
 
 							// push the child menu into its parent menu children property.
-							array_push( $menu_items[ $key ]['children'], $submenu_item );
-
+							array_push($menu_items[$key]['children'], $submenu_item);
 						}
 					}
 				}
 			}
 		}
 
-		$menu_items = ! empty( $menu_items ) ? $menu_items : '';
+		$menu_items = !empty($menu_items) ? $menu_items : '';
 
 		// Return menu post objects.
 		return $menu_items;
-
 	}
 
 	/**
@@ -265,15 +282,15 @@ class Header_Footer_Api {
 	 *
 	 * @return false|string
 	 */
-	public function get_sidebar( $sidebar_id ) {
+	public function get_sidebar($sidebar_id)
+	{
 		ob_start();
 
-		dynamic_sidebar( $sidebar_id );
+		dynamic_sidebar($sidebar_id);
 		$output = ob_get_contents();
 
 		ob_end_clean();
 
 		return $output;
 	}
-
 }


### PR DESCRIPTION
## Issue:
I encountered an issue with the `get_custom_logo_url` function where a warning was triggered due to attempting to access an array offset on a boolean value. This warning occurred on line 139 of the `class-header-footer-api.php` file in the `headless-cms-master` plugin. The warning arose because the function did not handle scenarios where the theme either did not support a custom logo or when no logo was set.

`<b>Warning</b>: Trying to access array offset on value of type bool in <b>/home/baloch/Local Sites/headless/app/public/wp-content/plugins/headless-cms-master/inc/classes/api/class-header-footer-api.php</b> on line <b>139</b><br />`

Additionally, there's an existing issue (#33) titled "Cannot find custom logo" that seems related to the same warning message.


## Solution:
To address this issue comprehensively, I made the following improvements:
- Utilized the `has_custom_logo()` function to check if the current theme supports a custom logo.
- Added a check to verify if a custom logo ID exists before attempting to retrieve the custom logo URL.
- Provided a fallback URL or value if the theme doesn't support a custom logo or if no logo is set.

These changes ensure that the `get_custom_logo_url` function gracefully handles variations in theme configurations, preventing the warning from being triggered and providing a more robust solution overall.